### PR TITLE
Add support for html element to measure

### DIFF
--- a/packages/svg/src/__tests__/utils.test.js
+++ b/packages/svg/src/__tests__/utils.test.js
@@ -32,10 +32,13 @@ describe('utils', () => {
     });
 
     it('should use getBoundingClientRect (if available)', () => {
-      // TODO
-      // 1. ...append('div')
-      // 2. Mock div.node with HTMLElement
-      // 3. measure(div)
+      const div = fixture.append('div');
+
+      div.node = jest.fn(() => {
+        return new HTMLElement({ size: { width: 100, height: 50 } });
+      });
+
+      expect(measure(div)).toEqual({ width: 100, height: 50 });
     });
   });
 });

--- a/packages/svg/src/utils.js
+++ b/packages/svg/src/utils.js
@@ -35,7 +35,11 @@ export function measure(selection) {
   }
 
   try {
-    const bbox = node.getBBox();
+    if (node.hasOwnProperty("getBBox")) {
+      const bbox = node.getBBox();
+    } else {
+      const bbox = node.getBoundingClientRect();
+    }
     return { width: bbox.width, height: bbox.height };
   } catch (err) {
     return { width: NaN, height: NaN };

--- a/packages/svg/src/utils.js
+++ b/packages/svg/src/utils.js
@@ -35,10 +35,11 @@ export function measure(selection) {
   }
 
   try {
-    if (node.hasOwnProperty("getBBox")) {
-      const bbox = node.getBBox();
+    let bbox;
+    if (typeof node.getBBox === "function") {
+      bbox = node.getBBox();
     } else {
-      const bbox = node.getBoundingClientRect();
+      bbox = node.getBoundingClientRect();
     }
     return { width: bbox.width, height: bbox.height };
   } catch (err) {


### PR DESCRIPTION
I made the change to allow elements other than svg to be measured. I used Object.hasOwnProperty to check if getBBox was available.